### PR TITLE
feat: Add nvim-tree and lualine setup configurations

### DIFF
--- a/nvim/bundles.lua
+++ b/nvim/bundles.lua
@@ -155,7 +155,16 @@ require('packer').startup(function(use)
   -- }
   use {
     'nvimtools/none-ls.nvim',
-    requires = { 'nvim-lua/plenary.nvim' }
+    requires = { 'nvim-lua/plenary.nvim' },
+    config = function()
+      require('none-ls').setup({
+        sources = {
+          require('none-ls').builtins.diagnostics.eslint_d,
+          require('none-ls').builtins.formatting.eslint_d,
+          require('none-ls').builtins.formatting.prettier,
+        },
+      })
+    end,
   }
 
 end)

--- a/nvim/bundles.lua
+++ b/nvim/bundles.lua
@@ -153,7 +153,6 @@ require('packer').startup(function(use)
   --   'jose-elias-alvarez/null-ls.nvim',
   --   requires = { 'nvim-lua/plenary.nvim' }
   -- }
-  --
   use {
     'nvimtools/none-ls.nvim',
     requires = { 'nvim-lua/plenary.nvim' }

--- a/nvim/bundles.lua
+++ b/nvim/bundles.lua
@@ -153,6 +153,7 @@ require('packer').startup(function(use)
   --   'jose-elias-alvarez/null-ls.nvim',
   --   requires = { 'nvim-lua/plenary.nvim' }
   -- }
+  --
   use {
     'nvimtools/none-ls.nvim',
     requires = { 'nvim-lua/plenary.nvim' }

--- a/nvim/bundles.lua
+++ b/nvim/bundles.lua
@@ -154,17 +154,8 @@ require('packer').startup(function(use)
   --   requires = { 'nvim-lua/plenary.nvim' }
   -- }
   use {
-    'nvimtools/none-ls.nvim',
-    requires = { 'nvim-lua/plenary.nvim' },
-    config = function()
-      require('none-ls').setup({
-        sources = {
-          require('none-ls').builtins.diagnostics.eslint_d,
-          require('none-ls').builtins.formatting.eslint_d,
-          require('none-ls').builtins.formatting.prettier,
-        },
-      })
-    end,
+    "nvimtools/none-ls.nvim",
+    requires = { "nvim-lua/plenary.nvim" },
   }
 
 end)

--- a/nvim/bundles.lua
+++ b/nvim/bundles.lua
@@ -149,8 +149,12 @@ require('packer').startup(function(use)
   -- use 'CoderCookE/vim-chatgpt'
   --
 
+  -- use {
+  --   'jose-elias-alvarez/null-ls.nvim',
+  --   requires = { 'nvim-lua/plenary.nvim' }
+  -- }
   use {
-    'jose-elias-alvarez/null-ls.nvim',
+    'nvimtools/none-ls.nvim',
     requires = { 'nvim-lua/plenary.nvim' }
   }
 

--- a/nvim/bundles.lua
+++ b/nvim/bundles.lua
@@ -64,7 +64,7 @@ require('packer').startup(function(use)
   use 'christoomey/vim-tmux-navigator'
   use 'mattn/gist-vim'
   -- use 'rking/ag.vim'
-  use 'KhoaRB/nerdtree'
+  -- use 'KhoaRB/nerdtree'
   use 'ryanoasis/vim-devicons'
   use 'tpope/vim-unimpaired'
   use 'yggdroot/indentline'
@@ -83,6 +83,17 @@ require('packer').startup(function(use)
   use 'vim-airline/vim-airline'
   use 'vim-airline/vim-airline-themes'
   use 'folke/tokyonight.nvim'
+  use 'nvim-tree/nvim-web-devicons'
+  use {
+    'nvim-lualine/lualine.nvim',
+    requires = { 'nvim-tree/nvim-web-devicons', opt = true }
+  }
+  use {
+    'nvim-tree/nvim-tree.lua',
+    requires = {
+      'nvim-tree/nvim-web-devicons', -- optional, for file icons
+    },
+  }
 
   -- TMP
   -- use 'bendavis78/vim-polymer'

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -88,6 +88,59 @@ require('moiday').setup({
   }
 })
 
+require('nvim-web-devicons').setup({
+  default = true,
+})
+
+vim.cmd([[
+  command! NERDTree NvimTreeToggle
+  command! NERDTreeToggle NvimTreeToggle
+  command! NERDTreeFind NvimTreeFindFile
+  command! NERDTreeRefresh NvimTreeRefresh
+  command! NERDTreeFocus NvimTreeFocus
+]])
+-- Set up nvim-tree
+require("nvim-tree").setup({
+  filters = {
+    dotfiles = true, -- Hide dotfiles
+    custom = {
+      '.git', -- Hide .git directory
+      'node_modules', -- Hide node_modules directory
+      'vendor', -- Hide vendor directory
+      'tmp', -- Hide tmp directory
+      'log', -- Hide log files
+      'public', -- Hide public directory
+    },
+  },
+  renderer = {
+    icons = {
+      show = {
+        file = true,
+        folder = true,
+        folder_arrow = true,
+        git = true,
+      },
+    }
+  },
+  git = {
+    enable = true,
+  },
+  view = {
+    width = 30,
+    side = 'left',
+  },
+})
+
+-- Set up lualine
+require('lualine').setup({
+  options = {
+    icons_enabled = true,
+    theme = 'catppuccin-mocha',
+    component_separators = { left = '', right = '' },
+    section_separators = { left = '', right = '' },
+  },
+})
+
 -- ESLint Linter and Auto Formatter
 local null_ls = require("null-ls")
 null_ls.setup({

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -178,13 +178,3 @@ require('lualine').setup({
     lualine_z = { 'location' }
   },
 })
-
--- ESLint Linter and Auto Formatter
-local null_ls = require("null-ls")
-null_ls.setup({
-  sources = {
-    null_ls.builtins.diagnostics.eslint_d, -- ESLint Linter
-    null_ls.builtins.formatting.eslint_d, -- ESLint Auto Formatter
-    require("null-ls").builtins.formatting.prettier,
-  },
-})

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -98,6 +98,7 @@ vim.cmd([[
   command! NERDTreeFind NvimTreeFindFile
   command! NERDTreeRefresh NvimTreeRefresh
   command! NERDTreeFocus NvimTreeFocus
+  command! NERDTreeClose NvimTreeClose
 ]])
 -- Set up nvim-tree
 require("nvim-tree").setup({
@@ -138,6 +139,43 @@ require('lualine').setup({
     theme = 'catppuccin-mocha',
     component_separators = { left = '', right = '' },
     section_separators = { left = '', right = '' },
+  },
+  sections = {
+    lualine_a = { 'mode' },
+    lualine_b = {
+      {
+        'branch',
+        icon = '', -- Git branch icon
+        colored = true, -- Color the branch name
+        fmt = function(branch)
+          local win_width = vim.api.nvim_win_get_width(0)
+          local max_length = math.floor(win_width * 0.2106) -- 21.06% of the window width
+
+          if #branch > max_length then
+            local head = branch:sub(1, math.floor(max_length * 0.6)) -- 60% of max_length
+            local tail = branch:sub(-math.floor(max_length * 0.4)) -- 40% of max_length
+            return head .. '...' .. tail
+          else
+            return branch
+          end
+        end,
+      },
+      {
+        'diff',
+        colored = true, -- Color the diff indicators
+        symbols = { added = ' ', modified = ' ', removed = ' ' }, -- Symbols for added, modified, and removed
+      }
+    },
+    lualine_c = {
+      {
+        'filename',
+        path = 1, -- 0: Just the filename, 1: Relative path, 2: Absolute path
+        shorting_target = 40, -- Shorten the filename to fit in the status line
+      }
+    },
+    lualine_x = { 'filetype' },
+    lualine_y = { 'progress' },
+    lualine_z = { 'location' }
   },
 })
 

--- a/nvim/local.vim
+++ b/nvim/local.vim
@@ -396,9 +396,9 @@ let g:gitgutter_sign_modified = ''
 let g:gitgutter_sign_removed = ''
 let g:gitgutter_sign_modified_removed = ''
 
-highlight GitGutterAdd    guifg=#009900 ctermfg=2 guibg=#052229 ctermbg=NONE
-highlight GitGutterChange guifg=#bbbb00 ctermfg=3 guibg=#052229 ctermbg=NONE
-highlight GitGutterDelete guifg=#ff2222 ctermfg=1 guibg=#052229 ctermbg=NONE
+highlight GitGutterAdd    guifg=#009900 ctermfg=2 guibg=NONE ctermbg=NONE
+highlight GitGutterChange guifg=#bbbb00 ctermfg=3 guibg=NONE ctermbg=NONE
+highlight GitGutterDelete guifg=#ff2222 ctermfg=1 guibg=NONE ctermbg=NONE
 
 
 """"""""""""""""""""""""""""""""""""""""
@@ -600,7 +600,7 @@ function! AutoSetColorScheme()
   let l:hour = str2nr(strftime("%H"))
 
   if l:hour >= 7 && l:hour < 18
-    colorscheme tokyonight-night
+    colorscheme catppuccin-macchiato
   else
     colorscheme catppuccin-mocha
   endif

--- a/nvim/plugin/packer_compiled.lua
+++ b/nvim/plugin/packer_compiled.lua
@@ -144,6 +144,11 @@ _G.packer_plugins = {
     path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/indentline",
     url = "https://github.com/yggdroot/indentline"
   },
+  ["lualine.nvim"] = {
+    loaded = true,
+    path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/lualine.nvim",
+    url = "https://github.com/nvim-lualine/lualine.nvim"
+  },
   ["matchit.zip"] = {
     loaded = true,
     path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/matchit.zip",
@@ -154,20 +159,30 @@ _G.packer_plugins = {
     path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/moiday.nvim",
     url = "https://github.com/ThanhKhoaIT/moiday.nvim"
   },
-  nerdtree = {
-    loaded = true,
-    path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/nerdtree",
-    url = "https://github.com/KhoaRB/nerdtree"
-  },
   ["null-ls.nvim"] = {
     loaded = true,
     path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/null-ls.nvim",
     url = "https://github.com/jose-elias-alvarez/null-ls.nvim"
   },
+  nvim = {
+    loaded = true,
+    path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/nvim",
+    url = "https://github.com/catppuccin/nvim"
+  },
   ["nvim-compe"] = {
     loaded = true,
     path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/nvim-compe",
     url = "https://github.com/hrsh7th/nvim-compe"
+  },
+  ["nvim-tree.lua"] = {
+    loaded = true,
+    path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/nvim-tree.lua",
+    url = "https://github.com/nvim-tree/nvim-tree.lua"
+  },
+  ["nvim-web-devicons"] = {
+    loaded = true,
+    path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/nvim-web-devicons",
+    url = "https://github.com/nvim-tree/nvim-web-devicons"
   },
   ["packer.nvim"] = {
     loaded = true,
@@ -208,6 +223,11 @@ _G.packer_plugins = {
     loaded = true,
     path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/tmuxline.vim",
     url = "https://github.com/edkolev/tmuxline.vim"
+  },
+  ["tokyonight.nvim"] = {
+    loaded = true,
+    path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/tokyonight.nvim",
+    url = "https://github.com/folke/tokyonight.nvim"
   },
   ["vim-airline"] = {
     loaded = true,

--- a/nvim/plugin/packer_compiled.lua
+++ b/nvim/plugin/packer_compiled.lua
@@ -159,10 +159,10 @@ _G.packer_plugins = {
     path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/moiday.nvim",
     url = "https://github.com/ThanhKhoaIT/moiday.nvim"
   },
-  ["null-ls.nvim"] = {
+  ["none-ls.nvim"] = {
     loaded = true,
-    path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/null-ls.nvim",
-    url = "https://github.com/jose-elias-alvarez/null-ls.nvim"
+    path = "/Users/tuanle/.local/share/nvim/site/pack/packer/start/none-ls.nvim",
+    url = "https://github.com/nvimtools/none-ls.nvim"
   },
   nvim = {
     loaded = true,


### PR DESCRIPTION
This pull request introduces significant updates to the Neovim configuration, focusing on plugin management, UI enhancements, and code cleanup. Key changes include replacing outdated plugins, adding new plugins for improved functionality, and refining the color scheme and Git integration. Below is a breakdown of the most important changes grouped by theme.

### Plugin Management Updates:
* Replaced the `nerdtree` plugin with `nvim-tree.lua` for file navigation, including optional support for `nvim-web-devicons` for file icons. (`nvim/bundles.lua` [[1]](diffhunk://#diff-a304d079fd1735e71316b8e57418afa93eba2c49835e8855233f893bf260c525L67-R67) [[2]](diffhunk://#diff-a304d079fd1735e71316b8e57418afa93eba2c49835e8855233f893bf260c525R86-R96); `nvim/plugin/packer_compiled.lua` [[3]](diffhunk://#diff-8d66f1667bdaafb564fbc1034d22edc9d82b786d108b92ed11d3764a098ab370L157-R186) [[4]](diffhunk://#diff-8d66f1667bdaafb564fbc1034d22edc9d82b786d108b92ed11d3764a098ab370R147-R151)
* Replaced `null-ls.nvim` with `none-ls.nvim` for linting and formatting functionality. (`nvim/bundles.lua` [[1]](diffhunk://#diff-a304d079fd1735e71316b8e57418afa93eba2c49835e8855233f893bf260c525R152-R157); `nvim/plugin/packer_compiled.lua` [[2]](diffhunk://#diff-8d66f1667bdaafb564fbc1034d22edc9d82b786d108b92ed11d3764a098ab370L157-R186)

### UI Enhancements:
* Added and configured `lualine.nvim` for a customizable status line, including Git branch truncation logic and diff indicators. (`nvim/bundles.lua` [[1]](diffhunk://#diff-a304d079fd1735e71316b8e57418afa93eba2c49835e8855233f893bf260c525R86-R96); `nvim/init.lua` [[2]](diffhunk://#diff-8cb544b4cf90adf36ca7c145b5bf73c08a6e56624099821a29e0653d0dfa6099R91-R181)
* Updated the color scheme logic to use `catppuccin-macchiato` during the day and `catppuccin-mocha` at night. (`nvim/local.vim` [nvim/local.vimL603-R603](diffhunk://#diff-4a51e5301efed5d583652a01629c6e3db827fd7d8034040d6a95b956542e44dcL603-R603))

### Git Integration Refinements:
* Modified GitGutter highlights to remove background colors for a cleaner visual appearance. (`nvim/local.vim` [nvim/local.vimL399-R401](diffhunk://#diff-4a51e5301efed5d583652a01629c6e3db827fd7d8034040d6a95b956542e44dcL399-R401))

### File Navigation Improvements:
* Configured `nvim-tree.lua` with filters to hide specific directories and files (e.g., `.git`, `node_modules`) and enabled Git integration for the file tree. (`nvim/init.lua` [nvim/init.luaR91-R181](diffhunk://#diff-8cb544b4cf90adf36ca7c145b5bf73c08a6e56624099821a29e0653d0dfa6099R91-R181))

These updates collectively enhance the usability, aesthetics, and functionality of the Neovim setup.