### PR TITLE
feat: Add instructions to reload Tmux configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ You can create symbolic links to the configuration files in your home directory.
     ```bash
     exec zsh
     ```
+6. **Reload Tmux configuration**:
+    Start a new Tmux session or reload your Tmux configuration:
+    ```bash
+    tmux source-file ~/.tmux.conf
+    ```
 
 ## ⚙️ Requirements
 - **Neovim**: Version 0.8 or higher

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -103,7 +103,7 @@ vim.cmd([[
 -- Set up nvim-tree
 require("nvim-tree").setup({
   filters = {
-    dotfiles = true, -- Hide dotfiles
+    -- dotfiles = true, -- Hide dotfiles
     custom = {
       '.git', -- Hide .git directory
       'node_modules', -- Hide node_modules directory


### PR DESCRIPTION
This pull request includes updates to the documentation and configuration files for improved usability and clarity. The most important changes involve adding instructions for reloading Tmux configuration and modifying the `nvim-tree` setup to adjust the visibility of dotfiles.

### Documentation Improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R92-R96): Added instructions for reloading the Tmux configuration, including a command to source the Tmux configuration file (`~/.tmux.conf`).

### Configuration Updates:
* [`nvim/init.lua`](diffhunk://#diff-8cb544b4cf90adf36ca7c145b5bf73c08a6e56624099821a29e0653d0dfa6099L106-R106): Commented out the `dotfiles` filter in the `nvim-tree` setup, which previously hid dotfiles by default. This change allows dotfiles to be visible in the file tree.