### PR TITLE
feat: Add tmuxinator configuration directory

### DIFF
--- a/tmuxinator/tmuxinator
+++ b/tmuxinator/tmuxinator
@@ -1,0 +1,1 @@
+/Users/tuanle/.config/tmuxinator


### PR DESCRIPTION
This pull request makes a small change to the `tmuxinator/tmuxinator` file by adding a new configuration path. This addition specifies `/Users/tuanle/.config/tmuxinator` as a configuration directory.