### PR TITLE
feat: Update tmuxinator configuration with new panes

### DIFF
--- a/config/tmuxinator/lixicrm.yml
+++ b/config/tmuxinator/lixicrm.yml
@@ -52,14 +52,24 @@ windows:
       panes:
         - nvim
   - console:
+      layout: even-horizontal
       panes:
-        - bundle exec rails console
+        - bundle; cl; rc
+        -
   - server:
       layout: main-horizontal
       panes:
-        - bundle exec rails s
-        - bin/vite dev
+        - bundle; cl; rs
+        - bundle; cl; bin/vite dev
         - tail -f log/development.log
+  - services:
+      layout: tiled
+      panes:
+        - bundle; cl; bundle exec sidekiq
+        - mailhog
+  - zrok:
+      panes:
+        - zrok share reserved lixicrm --headless
   - git:
       panes:
         - git status


### PR DESCRIPTION
This pull request updates the `tmuxinator` configuration file for the `lixicrm` project to streamline pane commands, add a new `services` window, and introduce a `zrok` window for specific tasks. The most important changes include simplifying commands, adding new windows, and adjusting layouts for better usability.

### Simplification of commands:
* Simplified pane commands in the `console` window by replacing `bundle exec rails console` with `bundle; cl; rc`.
* Simplified pane commands in the `server` window by replacing `bundle exec rails s` and `bin/vite dev` with `bundle; cl; rs` and `bundle; cl; bin/vite dev`.

### Addition of new windows:
* Added a new `services` window with a `tiled` layout, including panes for running `sidekiq` and `mailhog`.
* Added a new `zrok` window with a pane for running the `zrok share reserved lixicrm --headless` command.

### Layout adjustments:
* Added an `even-horizontal` layout to the `console` window for better pane organization.