### PR TITLE
feat: Add tmuxinator config for lixiadmin project

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ This setup is optimized for daily use in software engineering, with support for 
 ```bash
 dotfiles/
 ├── config/
-│   └── tmuxinator/
-│       └── lixicrm.yml  # Tmuxinator project configuration
+│   └── tmuxinator/        # Tmuxinator project configuration
+│       ├── lixicrm.yml
+│       └── lixiadmin.yml
 ├── nvim/                  # Neovim config (Lua + Vimscript)
 │   ├── init.lua
 │   ├── local.vim

--- a/config/tmuxinator/lixiadmin.yml
+++ b/config/tmuxinator/lixiadmin.yml
@@ -1,0 +1,69 @@
+# /Users/tuanle/.config/tmuxinator/lixiadmin.yml
+
+name: lixiadmin
+root: ~/projects/Lixibox/lixibox
+
+# Optional tmux socket
+# socket_name: foo
+
+# Note that the pre and post options have been deprecated and will be replaced by
+# project hooks.
+
+# Project hooks
+
+# Runs on project start, always
+# on_project_start: command
+
+# Run on project start, the first time
+# on_project_first_start: command
+
+# Run on project start, after the first time
+# on_project_restart: command
+
+# Run on project exit ( detaching from tmux session )
+# on_project_exit: command
+
+# Run on project stop
+# on_project_stop: command
+
+# Runs in each window and pane before window/pane specific commands. Useful for setting up interpreter versions.
+# pre_window: rbenv shell 2.0.0-p247
+
+# Pass command line options to tmux. Useful for specifying a different tmux.conf.
+# tmux_options: -f ~/.tmux.mac.conf
+
+# Change the command to call tmux. This can be used by derivatives/wrappers like byobu.
+# tmux_command: byobu
+
+# Specifies (by name or index) which window will be selected on project startup. If not set, the first window is used.
+# startup_window: editor
+
+# Specifies (by index) which pane of the specified window will be selected on project startup. If not set, the first pane is used.
+# startup_pane: 1
+
+# Controls whether the tmux session should be attached to automatically. Defaults to true.
+# attach: false
+
+startup_window: editor
+
+windows:
+  - editor:
+      layout: even-horizontal
+      panes:
+        - nvim
+  - console:
+      panes:
+        - rc
+  - server:
+      layout: main-horizontal
+      panes:
+        - rs -p 4000
+        - sh -c 'lsof -i :6379 -t | xargs -r kill -9; redis-server'
+  - docker:
+      layout: even-vertical
+      panes:
+        - sh -c 'docker inspect -f "{{.State.Running}}" lixibox_elasticsearch 2>/dev/null | grep true || docker start lixibox_elasticsearch; docker attach lixibox_elasticsearch'
+        - sh -c 'docker inspect -f "{{.State.Running}}" lixibox_mongodb 2>/dev/null | grep true || docker start lixibox_mongodb; docker attach lixibox_mongodb'
+  - git:
+      panes:
+        - git status


### PR DESCRIPTION
This pull request introduces a new `tmuxinator` configuration file for the `lixiadmin` project. The configuration defines a structured tmux session setup to streamline development workflows by organizing windows and panes for various tasks.

### New `tmuxinator` configuration:

* **File added:** `config/tmuxinator/lixiadmin.yml`  
  - Defines a `tmux` session named `lixiadmin` with the project root set to `~/projects/Lixibox/lixibox`.  
  - Configures five windows (`editor`, `console`, `server`, `docker`, `git`) with specific layouts and commands for each pane.  
  - Includes commands for commonly used tools like `nvim`, `redis-server`, `docker`, and `git`.  
  - Specifies `editor` as the startup window.