### PR TITLE
feat: Add sidekiq and services in tmuxinator configurations

### DIFF
--- a/config/tmuxinator/lixicrm.yml
+++ b/config/tmuxinator/lixicrm.yml
@@ -52,14 +52,24 @@ windows:
       panes:
         - nvim
   - console:
+      layout: even-horizontal
       panes:
-        - bundle exec rails console
+        - bundle; cl; rc
+        -
   - server:
       layout: main-horizontal
       panes:
-        - bundle exec rails s
-        - bin/vite dev
+        - bundle; cl; rs
+        - bundle; cl; bin/vite dev
         - tail -f log/development.log
+  - services:
+      layout: tiled
+      panes:
+        - bundle; cl; bundle exec sidekiq
+        - mailhog
+  - zrok:
+      panes:
+        - zrok share reserved lixicrm --headless
   - git:
       panes:
         - git status

--- a/config/tmuxinator/lixihalio.yml
+++ b/config/tmuxinator/lixihalio.yml
@@ -1,7 +1,7 @@
-# /Users/tuanle/.config/tmuxinator/lixiadmin.yml
+# /Users/tuanle/.config/tmuxinator/lixihalio.yml
 
-name: lixiadmin
-root: ~/projects/Lixibox/lixibox
+name: lixihalio
+root: ~/projects/Lixibox/halio-warranty
 
 # Optional tmux socket
 # socket_name: foo
@@ -55,16 +55,5 @@ windows:
       panes:
         - rc
   - server:
-      layout: main-horizontal
       panes:
-        - rs -p 4000
-        - sh -c 'lsof -i :6379 -t | xargs -r kill -9; redis-server'
-        - bundle exec sidekiq
-  - docker:
-      layout: even-vertical
-      panes:
-        - sh -c 'docker inspect -f "{{.State.Running}}" lixibox_elasticsearch 2>/dev/null | grep true || docker start lixibox_elasticsearch; docker attach lixibox_elasticsearch'
-        - sh -c 'docker inspect -f "{{.State.Running}}" lixibox_mongodb 2>/dev/null | grep true || docker start lixibox_mongodb; docker attach lixibox_mongodb'
-  - git:
-      panes:
-        - git status
+        - rs -p 5500


### PR DESCRIPTION
This pull request introduces updates to `tmuxinator` configuration files for various projects to enhance developer workflows by adding new panes, layouts, and a new configuration file. The changes aim to streamline commonly used commands and improve session organization.

### Updates to existing configurations:

* **`config/tmuxinator/lixiadmin.yml`:**
  - Added a new pane to run `bundle exec sidekiq` in the `windows:` section to support background job processing.

* **`config/tmuxinator/lixicrm.yml`:**
  - Updated the `console` window to use a horizontal layout and replaced `bundle exec rails console` with a shorthand command sequence (`bundle; cl; rc`) for efficiency.
  - Modified the `server` window commands to use shorthand sequences (`bundle; cl; rs` and `bundle; cl; bin/vite dev`) for consistency.
  - Added a new `services` window with a tiled layout for running `sidekiq` and `mailhog`, and a `zrok` window for sharing resources.

### Addition of a new configuration:

* **`config/tmuxinator/lixihalio.yml`:**
  - Introduced a new `tmuxinator` configuration file for the `lixihalio` project, including three windows (`editor`, `console`, and `server`) with specific layouts and commands tailored for project workflows.