### PR TITLE
feat: Add tmuxinator configuration for project "puchi"

### DIFF
--- a/config/tmuxinator/puchi.yml
+++ b/config/tmuxinator/puchi.yml
@@ -1,0 +1,61 @@
+# /Users/tuanle/.config/tmuxinator/puchi.yml
+
+name: puchi
+root: ~/projects/puchi
+
+# Optional tmux socket
+# socket_name: foo
+
+# Note that the pre and post options have been deprecated and will be replaced by
+# project hooks.
+
+# Project hooks
+
+# Runs on project start, always
+# on_project_start: command
+
+# Run on project start, the first time
+# on_project_first_start: command
+
+# Run on project start, after the first time
+# on_project_restart: command
+
+# Run on project exit ( detaching from tmux session )
+# on_project_exit: command
+
+# Run on project stop
+# on_project_stop: command
+
+# Runs in each window and pane before window/pane specific commands. Useful for setting up interpreter versions.
+# pre_window: rbenv shell 2.0.0-p247
+
+# Pass command line options to tmux. Useful for specifying a different tmux.conf.
+# tmux_options: -f ~/.tmux.mac.conf
+
+# Change the command to call tmux. This can be used by derivatives/wrappers like byobu.
+# tmux_command: byobu
+
+# Specifies (by name or index) which window will be selected on project startup. If not set, the first window is used.
+# startup_window: editor
+
+# Specifies (by index) which pane of the specified window will be selected on project startup. If not set, the first pane is used.
+# startup_pane: 1
+
+# Controls whether the tmux session should be attached to automatically. Defaults to true.
+# attach: false
+
+startup_window: editor
+windows:
+  - editor:
+      layout: even-horizontal
+      panes:
+        - nvim
+  - console:
+      panes:
+        - rc
+  - server:
+      panes:
+        - rs -p 2106
+  - git:
+      panes:
+        - git status


### PR DESCRIPTION
This pull request adds a new tmuxinator configuration file for the `puchi` project. The file defines the tmux session setup, including window layouts and commands for common development tasks.

Development environment setup:

* Added `config/tmuxinator/puchi.yml` to provide a tmuxinator configuration for the `puchi` project, specifying session name, root directory, window layouts, and startup commands for `editor`, `console`, `server`, and `git` windows.