### PR TITLE
feat: Add tmuxinator config for dentist-portfolio

### DIFF
--- a/config/tmuxinator/dentist-portfolio.yml
+++ b/config/tmuxinator/dentist-portfolio.yml
@@ -1,0 +1,61 @@
+# /Users/tuanle/.config/tmuxinator/dentist-portfolio.yml
+
+name: dentist-portfolio
+root: ~/projects/dentist-portfolio
+
+# Optional tmux socket
+# socket_name: foo
+
+# Note that the pre and post options have been deprecated and will be replaced by
+# project hooks.
+
+# Project hooks
+
+# Runs on project start, always
+# on_project_start: command
+
+# Run on project start, the first time
+# on_project_first_start: command
+
+# Run on project start, after the first time
+# on_project_restart: command
+
+# Run on project exit ( detaching from tmux session )
+# on_project_exit: command
+
+# Run on project stop
+# on_project_stop: command
+
+# Runs in each window and pane before window/pane specific commands. Useful for setting up interpreter versions.
+# pre_window: rbenv shell 2.0.0-p247
+
+# Pass command line options to tmux. Useful for specifying a different tmux.conf.
+# tmux_options: -f ~/.tmux.mac.conf
+
+# Change the command to call tmux. This can be used by derivatives/wrappers like byobu.
+# tmux_command: byobu
+
+# Specifies (by name or index) which window will be selected on project startup. If not set, the first window is used.
+# startup_window: editor
+
+# Specifies (by index) which pane of the specified window will be selected on project startup. If not set, the first pane is used.
+# startup_pane: 1
+
+# Controls whether the tmux session should be attached to automatically. Defaults to true.
+# attach: false
+
+startup_window: editor
+windows:
+  - editor:
+      layout: even-horizontal
+      panes:
+        - nvim
+  - console:
+      panes:
+        - rc
+  - server:
+      panes:
+        - rs -p 7503
+  - git:
+      panes:
+        - git status


### PR DESCRIPTION
This pull request introduces a new tmuxinator configuration for the `dentist-portfolio` project. The configuration defines a multi-window tmux session setup to streamline development workflows for this project.

Project environment setup:

* Added `config/tmuxinator/dentist-portfolio.yml` to provide a tmuxinator configuration for the `dentist-portfolio` project, including windows for editing (`nvim`), running the console (`rc`), starting the server (`rs -p 7503`), and checking git status.