### PR TITLE
feat: Add ssh and cloudflare configurations to tmuxinator files

### DIFF
--- a/config/tmuxinator/dentist-portfolio.yml
+++ b/config/tmuxinator/dentist-portfolio.yml
@@ -56,6 +56,9 @@ windows:
   - server:
       panes:
         - rs -p 7503
-  - git:
+  - ssh:
+      layout: main-horizontal
       panes:
-        - git status
+        - ssh -t ec2-user@3.25.65.194 'cd dentist-portfolio && docker attach dentist-portfolio-app-1'
+        - ssh -t ec2-user@3.25.65.194 'cd dentist-portfolio && docker exec -it dentist-portfolio-app-1 bin/rails c'
+        - ssh -t ec2-user@3.25.65.194 'cd dentist-portfolio && docker attach dentist-portfolio-db-1'

--- a/config/tmuxinator/lixicrm.yml
+++ b/config/tmuxinator/lixicrm.yml
@@ -57,19 +57,18 @@ windows:
         - bundle; cl; rc
         -
   - server:
-      layout: main-horizontal
+      layout: even-horizontal
       panes:
         - bundle; cl; rs
         - bundle; cl; bin/vite dev
-        - tail -f log/development.log
   - services:
       layout: tiled
       panes:
         - bundle; cl; bundle exec sidekiq
         - mailhog
-  - zrok:
+  - cloudflare:
       panes:
-        - zrok share reserved lixicrm --headless
+        - cloudflared tunnel --config ~/.cloudflared/config.yml --protocol http2 run lixicrm
   - git:
       panes:
         - git status


### PR DESCRIPTION
This pull request updates the tmuxinator configuration files for two projects to improve remote development workflows and service management. The most important changes involve replacing local git pane usage with SSH-based Docker management for the `dentist-portfolio` project, and updating service panes and tunnel commands for the `lixicrm` project.

**Dentist Portfolio remote workflow improvements:**
* Replaced the local `git` window with an `ssh` window containing panes for attaching to and managing Docker containers on the remote server, including Rails console and database access. (`config/tmuxinator/dentist-portfolio.yml`)

**Lixicrm service and tunnel management updates:**
* Changed the `server` window layout from `main-horizontal` to `even-horizontal` for better pane distribution. (`config/tmuxinator/lixicrm.yml`)
* Removed the `tail -f log/development.log` pane from the `server` window to streamline the setup. (`config/tmuxinator/lixicrm.yml`)
* Renamed the `zrok` window to `cloudflare` and replaced the `zrok share reserved lixicrm --headless` command with `cloudflared tunnel --config ~/.cloudflared/config.yml --protocol http2 run lixicrm` for tunnel management. (`config/tmuxinator/lixicrm.yml`)