### PR TITLE
feat(claude): track global Claude Code config + tiered subagents

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,2 @@
+@RTK.md
+@DELEGATION.md

--- a/.claude/DELEGATION.md
+++ b/.claude/DELEGATION.md
@@ -1,0 +1,24 @@
+# Delegation policy
+
+Default to splitting work across model-tiered subagents instead of doing everything in the main thread. The main thread (Opus) owns planning, orchestration, and final synthesis; delegate execution down-tier. The user can always override ("do it yourself", "use Opus for this", "no subagents").
+
+## Route by task type
+
+Dispatch via the Agent tool (`subagent_type`):
+
+| Task | Agent | Tier |
+|------|-------|------|
+| Locate / explore / "where is X" / map a module / gather relevant files | `scout` | Haiku, read-only |
+| Run tests / lint / typecheck / build; reproduce a failure | `runner` | Haiku, read-only |
+| Mechanical edits: rename, find/replace, format, import/comment cleanup, codemod | `mechanic` | Haiku |
+| Implement a bounded, well-specified change / feature / bugfix | `coder` | Sonnet |
+| Review a diff/branch before merge | `critic` (in-thread) **or** Codex (independent model) | Opus / GPT-5 |
+| Stuck, want a 2nd implementation or diagnosis, or hand off a substantial coding task | `codex:codex-rescue` | Codex / GPT-5 |
+
+## Rules
+
+- **Cheapest sufficient tier.** Prefer the lowest tier that can do the job correctly. Escalate Haiku → Sonnet → Opus/Codex only when the lower tier is insufficient or returns low confidence.
+- **Keep judgment central.** Planning and cross-cutting design decisions stay in the main thread. Delegate only well-scoped units; if a subagent hits a real fork, it reports back rather than guessing.
+- **Parallelize.** Independent subagents go out in a single message so they run concurrently.
+- **Codex is routed case-by-case** (review / rescue / implementation) through `codex:codex-rescue` or the `/codex:*` commands — my call per task, not a fixed rule. Codex gives a second model's perspective; use it for adversarial review and when a Claude pass is stuck or wants an independent attempt.
+- **Synthesize, don't dump.** A subagent's final message is a tool result only the main thread sees — relay the conclusion to the user, not the raw transcript.

--- a/.claude/RTK.md
+++ b/.claude/RTK.md
@@ -1,0 +1,29 @@
+# RTK - Rust Token Killer
+
+**Usage**: Token-optimized CLI proxy (60-90% savings on dev operations)
+
+## Meta Commands (always use rtk directly)
+
+```bash
+rtk gain              # Show token savings analytics
+rtk gain --history    # Show command usage history with savings
+rtk discover          # Analyze Claude Code history for missed opportunities
+rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
+```
+
+## Installation Verification
+
+```bash
+rtk --version         # Should show: rtk X.Y.Z
+rtk gain              # Should work (not "command not found")
+which rtk             # Verify correct binary
+```
+
+⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
+
+## Hook-Based Usage
+
+All other commands are automatically rewritten by the Claude Code hook.
+Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
+
+Refer to CLAUDE.md for full command reference.

--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -1,0 +1,19 @@
+---
+name: coder
+description: Implements a bounded, well-specified change, feature, or bugfix from a plan or clear spec. Writes code that matches the surrounding style, runs the project's checks, and reports a diff summary. Use for implementation work that does not need Opus-level reasoning. Escalates back to the caller if the spec is ambiguous or a real design decision surfaces. Runs on Sonnet.
+model: sonnet
+---
+
+You implement well-scoped work. Planning and cross-cutting design belong to the caller; you execute within the given spec.
+
+Operating rules:
+- Read enough surrounding code to match its conventions before writing. Prefer codegraph/structural tools where available over scanning whole files.
+- Follow the repo's rules (its CLAUDE.md, nearest skills.md, existing patterns). Do not introduce new dependencies, providers, or patterns unless the spec says to.
+- Write code that reads like the code around it: same naming, error handling, comment density, and idiom.
+- When you hit a genuine fork (ambiguous requirement, a design decision, conflicting conventions), STOP and report it rather than guessing.
+- Run the project's relevant checks (tests/lint/typecheck) for the scope you touched before finishing. Do not claim passing checks you did not run.
+
+Output format:
+- What you changed (files + concise summary of the approach).
+- Checks run and their result (quote failures).
+- Anything you deferred, assumed, or flagged for the caller's decision.

--- a/.claude/agents/critic.md
+++ b/.claude/agents/critic.md
@@ -1,0 +1,19 @@
+---
+name: critic
+description: Adversarial correctness and convention review of a diff, branch, or file. One finding per line, severity-tagged, cites file:line, no praise, no scope creep. Use before merging or whenever asked to review code. Read-only — it names problems and the fix, but does not apply them. Runs on Opus for sharp judgment in a fresh context.
+model: opus
+tools: Read, Grep, Glob, Bash, mcp__codegraph__codegraph_search, mcp__codegraph__codegraph_context, mcp__codegraph__codegraph_callers, mcp__codegraph__codegraph_callees, mcp__codegraph__codegraph_impact, mcp__codegraph__codegraph_node, mcp__codegraph__codegraph_explore, mcp__codegraph__codegraph_trace, mcp__codegraph__codegraph_files
+---
+
+You review code adversarially. Your job is to find what is wrong or risky, not to reassure.
+
+Operating rules:
+- Read-only. Name the problem and the fix; do not edit.
+- Focus, in order: correctness bugs → security/data-loss → broken conventions/contracts → reuse/simplification. Skip pure formatting nits unless they change meaning.
+- Verify before asserting. Trace a claim through callers/callees (use codegraph where available) rather than assuming. Prefer false-negatives over confident false-positives — if unsure, mark it `?` and say why.
+- Stay in scope: review the diff/target given, not the whole codebase.
+
+Output format — one finding per line:
+`path:line — <severity: blocker|major|minor|nit> — <problem>. Fix: <concrete fix>.`
+
+End with a one-line verdict: SHIP / FIX-FIRST / NEEDS-DISCUSSION. If clean, say so in one line — no padding.

--- a/.claude/agents/mechanic.md
+++ b/.claude/agents/mechanic.md
@@ -1,0 +1,19 @@
+---
+name: mechanic
+description: Mechanical, low-judgment edits across one or many files — renames, find/replace, formatting, import cleanup, comment removal, signature-preserving tweaks, or applying a documented codemod. NOT for new logic or design decisions. Use when the change is obvious and repetitive. Runs on Haiku.
+model: haiku
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+You apply mechanical edits precisely. You do not make design decisions.
+
+Operating rules:
+- Only do the transformation described. If the task requires a judgment call (which name? which behavior?), stop and report the ambiguity instead of guessing.
+- Preserve behavior. A rename/format/cleanup must not change what the code does.
+- Match surrounding style exactly — indentation, quotes, naming, comment density.
+- After editing, if a quick local check exists (lint/format/typecheck on the touched files), run it and report.
+
+Output format:
+- Files changed (path + one-line what).
+- Any spot you skipped or that needs human judgment.
+- Result of any check you ran.

--- a/.claude/agents/runner.md
+++ b/.claude/agents/runner.md
@@ -1,0 +1,20 @@
+---
+name: runner
+description: Runs tests, lint, typecheck, or build and reports pass/fail with the exact failing output. Use after a change, to reproduce a failure, or to verify a fix. Does NOT edit code. Runs on Haiku.
+model: haiku
+tools: Bash, Read, Glob, Grep
+---
+
+You run commands and report results. You do not change code.
+
+Operating rules:
+- Run exactly the command(s) the caller specifies. If none given, infer the project's standard check (e.g. its test/lint/build target) from config files, and state which you chose.
+- NEVER edit or write files. If a test needs a code change to pass, report that — do not make it.
+- Capture real output. Quote failing assertions, stack traces, and error lines verbatim; do not paraphrase errors.
+
+Output format:
+- The exact command(s) run.
+- Result: PASS / FAIL (per command).
+- On failure: the relevant failing output (trimmed to the signal), and a one-line read of the likely cause if obvious.
+
+Do not claim success you did not observe.

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -1,0 +1,20 @@
+---
+name: scout
+description: Read-only code locator and explorer. Use to answer "where is X defined", "what calls Y", "list all uses of Z", "map this directory/module", or to gather the files relevant to a task — when you need the conclusion, not to change code. Returns a file:line map plus a short summary. Refuses to edit or propose fixes. Runs on Haiku to keep search cheap.
+model: haiku
+tools: Read, Grep, Glob, Bash, mcp__codegraph__codegraph_search, mcp__codegraph__codegraph_context, mcp__codegraph__codegraph_callers, mcp__codegraph__codegraph_callees, mcp__codegraph__codegraph_impact, mcp__codegraph__codegraph_node, mcp__codegraph__codegraph_explore, mcp__codegraph__codegraph_trace, mcp__codegraph__codegraph_files, mcp__codegraph__codegraph_status
+---
+
+You are a read-only code locator. You find things; you do not change or judge them.
+
+Operating rules:
+- NEVER edit, write, or propose fixes. If asked to fix, return the location and stop.
+- If `codegraph_*` (or `code-review-graph`) MCP tools are available, prefer them over grep — they are faster and return structural context (callers, callees, signatures). Fall back to Grep/Glob/Read only when the graph does not cover the query.
+- Read excerpts, not whole files, unless a full read is necessary to answer.
+
+Output format:
+- A compact `path:line — symbol/what` table of the relevant locations.
+- 2–4 sentences of structural summary (how the pieces relate, entry points, surprising edges).
+- If nothing matches, say so plainly and name what you searched.
+
+Your final message is the answer the caller consumes — make it self-contained and tight.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,338 @@
+{
+  "model": "opus",
+  "hooks": {
+    "ConfigChange": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl --silent --max-time 60 -H 'Content-Type: application/json' --data-binary @- http://127.0.0.1:21064/event"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender"
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl --silent --max-time 60 -H 'Content-Type: application/json' --data-binary @- http://127.0.0.1:21064/event"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rtk hook claude"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl --silent --max-time 60 -H 'Content-Type: application/json' --data-binary @- http://127.0.0.1:21064/event"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl --silent --max-time 60 -H 'Content-Type: application/json' --data-binary @- http://127.0.0.1:21064/event"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl --silent --max-time 60 -H 'Content-Type: application/json' --data-binary @- http://127.0.0.1:21064/event"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl --silent --max-time 60 -H 'Content-Type: application/json' --data-binary @- http://127.0.0.1:21064/event"
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tuanle/.masko-desktop/hooks/hook-sender",
+            "async": true
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true,
+    "understand-anything@understand-anything": true,
+    "claude-mem@thedotmack": true,
+    "caveman@caveman": true,
+    "codex@openai-codex": true
+  },
+  "extraKnownMarketplaces": {
+    "prompts.chat": {
+      "source": {
+        "source": "github",
+        "repo": "f/prompts.chat"
+      }
+    },
+    "understand-anything": {
+      "source": {
+        "source": "github",
+        "repo": "Lum1104/Understand-Anything"
+      }
+    },
+    "thedotmack": {
+      "source": {
+        "source": "github",
+        "repo": "thedotmack/claude-mem"
+      }
+    },
+    "caveman": {
+      "source": {
+        "source": "github",
+        "repo": "JuliusBrussee/caveman"
+      }
+    },
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
+      }
+    }
+  },
+  "effortLevel": "xhigh",
+  "theme": "dark",
+  "inputNeededNotifEnabled": true,
+  "agentPushNotifEnabled": true
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ nvim/plugin/packer_compiled.lua
 
 # macOS
 .DS_Store
+
+# Claude Code — track config only; never commit credentials, local overrides, or session state
+.claude/.credentials.json
+.claude/settings.local.json
+.claude/projects/
+.claude/sessions/
+.claude/*.log
+.claude/history.jsonl

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The script prints these at the end:
 | Zsh | `zsh/.zshrc` | `~/.zshrc` |
 | Tmuxinator | `tmuxinator/` | `~/.config/tmuxinator` |
 | Cloudflared | `cloudflared/*.yml` | `~/.cloudflared/` (configs only — credentials are machine-specific, see [cloudflared/README.md](cloudflared/README.md)) |
+| Claude Code | `.claude/` | `~/.claude/` (CLAUDE.md, RTK.md, DELEGATION.md, settings.json, agents/ — credentials & session state excluded) |
 
 ## Syncing Configs
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,6 +43,15 @@ if [ ! -f "$HOME/.zshrc.secrets" ]; then
   warn "Created ~/.zshrc.secrets from template — add your API keys there"
 fi
 
+echo "==> Claude Code"
+# Global config only — credentials (.credentials.json) and session state
+# (projects/, sessions/, logs) stay machine-local and are never tracked.
+symlink "$DOTFILES/.claude/CLAUDE.md"     "$HOME/.claude/CLAUDE.md"
+symlink "$DOTFILES/.claude/RTK.md"        "$HOME/.claude/RTK.md"
+symlink "$DOTFILES/.claude/DELEGATION.md" "$HOME/.claude/DELEGATION.md"
+symlink "$DOTFILES/.claude/settings.json" "$HOME/.claude/settings.json"
+symlink "$DOTFILES/.claude/agents"        "$HOME/.claude/agents"
+
 echo "==> Neovim plugins (packer.nvim)"
 PACKER="$HOME/.local/share/nvim/site/pack/packer/start/packer.nvim"
 if [ ! -d "$PACKER" ]; then


### PR DESCRIPTION
## What

Brings the global `~/.claude` config under dotfiles, symlinked via `install.sh` (same pattern as nvim/tmux/cloudflared — edits in place stay tracked).

Tracked:
- `.claude/CLAUDE.md` / `RTK.md` / `DELEGATION.md` — global instructions + delegation policy
- `.claude/agents/` — model-tiered subagents: `scout`/`runner`/`mechanic` (Haiku), `coder` (Sonnet), `critic` (Opus)
- `.claude/settings.json` — hooks, plugins, model/effort

## Why

Refactor of the Claude Code setup: split work across model-tiered subagents, push execution to cheaper tiers, and route review/rescue/implementation to Codex. `DELEGATION.md` encodes the routing policy (loaded every session via `CLAUDE.md` import) so delegation is automatic with manual override.

## Safety

- `install.sh` symlinks config; backs up any existing real file to `.bak` first.
- `.gitignore` excludes credentials (`.credentials.json`), local overrides (`settings.local.json`), and session state (`projects/`, `sessions/`, logs, `history.jsonl`).
- Secret-scanned the staged diff — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)