### PR TITLE
chore(claude): cut token usage — Codex-first delegation + leaner per-session context

### DIFF
--- a/.claude/DELEGATION.md
+++ b/.claude/DELEGATION.md
@@ -2,23 +2,30 @@
 
 Default to splitting work across model-tiered subagents instead of doing everything in the main thread. The main thread (Opus) owns planning, orchestration, and final synthesis; delegate execution down-tier. The user can always override ("do it yourself", "use Opus for this", "no subagents").
 
+## Token strategy: push execution off the Opus budget
+
+Every token the main thread spends *implementing* is an Opus token. Two levers move work off that budget:
+
+1. **Codex first for execution.** Codex (`codex:codex-rescue`, `/codex:*`) runs on a separate GPT-5 quota — its work never touches the Claude context or usage. For any well-specified coding/execution task that does not need Opus-level judgment, hand it to Codex. Cheapest path available: the main thread pays only the dispatch prompt + the synthesized result, not the implementation.
+2. **Cheapest Claude tier otherwise.** When Codex is unavailable, or the task is search/test/mechanical, drop to the lowest Claude tier that does it correctly (Haiku → Sonnet) — never Opus for execution.
+
 ## Route by task type
 
 Dispatch via the Agent tool (`subagent_type`):
 
-| Task | Agent | Tier |
-|------|-------|------|
+| Task | Route | Tier / cost |
+|------|-------|-------------|
+| Implement a well-specified change / feature / bugfix from a clear spec | **`codex:codex-rescue`** (default) → `coder` if Codex unavailable | GPT-5 (off Claude budget) / Sonnet |
+| Stuck; want a 2nd implementation, diagnosis, or deep root-cause pass | `codex:codex-rescue` | GPT-5 (off budget) |
 | Locate / explore / "where is X" / map a module / gather relevant files | `scout` | Haiku, read-only |
 | Run tests / lint / typecheck / build; reproduce a failure | `runner` | Haiku, read-only |
 | Mechanical edits: rename, find/replace, format, import/comment cleanup, codemod | `mechanic` | Haiku |
-| Implement a bounded, well-specified change / feature / bugfix | `coder` | Sonnet |
 | Review a diff/branch before merge | `critic` (in-thread) **or** Codex (independent model) | Opus / GPT-5 |
-| Stuck, want a 2nd implementation or diagnosis, or hand off a substantial coding task | `codex:codex-rescue` | Codex / GPT-5 |
 
 ## Rules
 
-- **Cheapest sufficient tier.** Prefer the lowest tier that can do the job correctly. Escalate Haiku → Sonnet → Opus/Codex only when the lower tier is insufficient or returns low confidence.
+- **Codex is the default executor.** Well-specified implementation work goes to Codex unless it needs Opus-level reasoning or Codex is unavailable (not logged in / offline) — then fall back to `coder` (Sonnet). Resolve ambiguous specs or live design decisions in the main thread *first*, then dispatch a clean spec.
+- **Cheapest sufficient tier.** Prefer the lowest tier/cost that does the job correctly. Escalate Codex/Haiku → Sonnet → Opus only when the lower option is insufficient or returns low confidence.
 - **Keep judgment central.** Planning and cross-cutting design decisions stay in the main thread. Delegate only well-scoped units; if a subagent hits a real fork, it reports back rather than guessing.
 - **Parallelize.** Independent subagents go out in a single message so they run concurrently.
-- **Codex is routed case-by-case** (review / rescue / implementation) through `codex:codex-rescue` or the `/codex:*` commands — my call per task, not a fixed rule. Codex gives a second model's perspective; use it for adversarial review and when a Claude pass is stuck or wants an independent attempt.
 - **Synthesize, don't dump.** A subagent's final message is a tool result only the main thread sees — relay the conclusion to the user, not the raw transcript.

--- a/.claude/DELEGATION.md
+++ b/.claude/DELEGATION.md
@@ -7,7 +7,8 @@ Default to splitting work across model-tiered subagents instead of doing everyth
 Every token the main thread spends *implementing* is an Opus token. Two levers move work off that budget:
 
 1. **Codex first for execution.** Codex (`codex:codex-rescue`, `/codex:*`) runs on a separate GPT-5 quota — its work never touches the Claude context or usage. For any well-specified coding/execution task that does not need Opus-level judgment, hand it to Codex. Cheapest path available: the main thread pays only the dispatch prompt + the synthesized result, not the implementation.
-2. **Cheapest Claude tier otherwise.** When Codex is unavailable, or the task is search/test/mechanical, drop to the lowest Claude tier that does it correctly (Haiku → Sonnet) — never Opus for execution.
+2. **Copilot as second off-budget executor.** `copilot-rescue` forwards a task to the GitHub Copilot CLI, which runs on the Copilot subscription quota — also off the Claude budget. Use it when Codex is unavailable, or to run a second executor in parallel. Note: it burns Copilot premium-request quota, so it trades cost pools rather than being free.
+3. **Cheapest Claude tier otherwise.** When both Codex and Copilot are unavailable, or the task is search/test/mechanical, drop to the lowest Claude tier that does it correctly (Haiku → Sonnet) — never Opus for execution.
 
 ## Route by task type
 
@@ -15,7 +16,7 @@ Dispatch via the Agent tool (`subagent_type`):
 
 | Task | Route | Tier / cost |
 |------|-------|-------------|
-| Implement a well-specified change / feature / bugfix from a clear spec | **`codex:codex-rescue`** (default) → `coder` if Codex unavailable | GPT-5 (off Claude budget) / Sonnet |
+| Implement a well-specified change / feature / bugfix from a clear spec | **`codex:codex-rescue`** (default) → `copilot-rescue` → `coder` if both unavailable | GPT-5 / Copilot (both off Claude budget) / Sonnet |
 | Stuck; want a 2nd implementation, diagnosis, or deep root-cause pass | `codex:codex-rescue` | GPT-5 (off budget) |
 | Locate / explore / "where is X" / map a module / gather relevant files | `scout` | Haiku, read-only |
 | Run tests / lint / typecheck / build; reproduce a failure | `runner` | Haiku, read-only |
@@ -24,7 +25,7 @@ Dispatch via the Agent tool (`subagent_type`):
 
 ## Rules
 
-- **Codex is the default executor.** Well-specified implementation work goes to Codex unless it needs Opus-level reasoning or Codex is unavailable (not logged in / offline) — then fall back to `coder` (Sonnet). Resolve ambiguous specs or live design decisions in the main thread *first*, then dispatch a clean spec.
+- **Codex is the default executor.** Well-specified implementation work goes to Codex unless it needs Opus-level reasoning or Codex is unavailable (not logged in / offline) — then fall back to `copilot-rescue`, and to `coder` (Sonnet) only if both are unavailable. Resolve ambiguous specs or live design decisions in the main thread *first*, then dispatch a clean spec.
 - **Cheapest sufficient tier.** Prefer the lowest tier/cost that does the job correctly. Escalate Codex/Haiku → Sonnet → Opus only when the lower option is insufficient or returns low confidence.
 - **Keep judgment central.** Planning and cross-cutting design decisions stay in the main thread. Delegate only well-scoped units; if a subagent hits a real fork, it reports back rather than guessing.
 - **Parallelize.** Independent subagents go out in a single message so they run concurrently.

--- a/.claude/agents/copilot-rescue.md
+++ b/.claude/agents/copilot-rescue.md
@@ -1,0 +1,24 @@
+---
+name: copilot-rescue
+description: Hand a well-specified coding or execution task to the GitHub Copilot CLI to keep that work off the Claude token budget. Use for bounded implementation, mechanical edits, or research that does not need Opus-level judgment, when Codex is unavailable or you want a second executor on a different quota. Forwards the task to `copilot` and returns its output unchanged.
+model: haiku
+tools: Bash
+---
+
+You are a thin forwarding wrapper around the GitHub Copilot CLI. Your only job is to forward the caller's task to `copilot` and return its output. Do nothing else.
+
+Forwarding rules:
+- Use exactly one `Bash` call to invoke the Copilot CLI in non-interactive mode:
+  `copilot -p "<the task text>" --allow-all-tools --log-level none --no-color`
+  (`--allow-all-tools` is required for non-interactive runs; the log/color flags keep stdout clean for forwarding.)
+- Pass the caller's task text through as-is. Do not rewrite, expand, or solve it yourself.
+- Do not inspect the repository, read files, grep, plan, or do any independent work beyond the single `copilot` call.
+- If the caller explicitly asks for read-only / review-only behavior, drop `--allow-all-tools` so Copilot cannot edit.
+- If the caller names a specific model, append `--model <name>`; otherwise leave it unset.
+
+Failure handling:
+- If `copilot` is not installed or not authenticated (command not found / auth error), return exactly: `copilot CLI unavailable — not installed or not logged in.` and stop.
+- If the call fails for another reason, return the stderr exactly as-is.
+
+Output:
+- Return Copilot's stdout exactly as-is. No commentary before or after.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -294,7 +294,7 @@
   },
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,
-    "understand-anything@understand-anything": true,
+    "understand-anything@understand-anything": false,
     "claude-mem@thedotmack": true,
     "caveman@caveman": true,
     "codex@openai-codex": true
@@ -331,7 +331,7 @@
       }
     }
   },
-  "effortLevel": "xhigh",
+  "effortLevel": "high",
   "theme": "dark",
   "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": true


### PR DESCRIPTION
## What
Token-reduction pass on the global Claude Code setup (stacked on #19, which adds the base `.claude/` config).

- **DELEGATION.md** — Codex is now the **default executor** for well-specified coding. Codex runs on a separate GPT-5 quota, so that work never touches the Claude token budget; `coder` (Sonnet) is the fallback when Codex is unavailable. Added a "push execution off the Opus budget" strategy section.
- **settings.json** — `effortLevel` `xhigh` → `high` (fewer thinking tokens per orchestrator turn); `understand-anything` plugin **disabled** (heaviest per-session context dump: ~10 agents + 8 skills injected every session).

## Why
Per-session context + Opus thinking tokens were the main cost. Routing execution to Codex and trimming always-on context cuts spend without losing the workflows actually in use (caveman, claude-mem, superpowers kept).

## Note
Based on `feat/claude-code-config` (#19) because the base `.claude/` config only exists on that branch. Rebase onto `main` once #19 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)